### PR TITLE
NO MERGE: Update local dependencies to bazel-friendly ones

### DIFF
--- a/foundationdb-bench/Cargo.toml
+++ b/foundationdb-bench/Cargo.toml
@@ -22,7 +22,7 @@ license = "MIT/Apache-2.0"
 
 [dependencies]
 env_logger = "0.9.0"
-foundationdb = { version = "*", path = "../foundationdb" }
+foundationdb = { version = "0.7.0-dd.1", path = "../foundationdb" }
 futures = "0.3.21"
 log = "0.4.17"
 rand = "0.8.5"

--- a/foundationdb/Cargo.toml
+++ b/foundationdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "foundationdb"
-version = "0.7.0"
+name = "foundationdb-dd"
+version = "0.7.0-dd.1"
 authors = [
     "Benjamin Fry <benjaminfry@me.com>",
     "Vincent Rouillé <vincent@clikengo.com>",
@@ -45,11 +45,11 @@ fdb-7_1 = ["foundationdb-sys/fdb-7_1", "foundationdb-gen/fdb-7_1", "serde", "ser
 tenant-experimental = []
 
 [build-dependencies]
-foundationdb-gen = { version = "0.7.0", path = "../foundationdb-gen", default-features = false }
+foundationdb-gen = { version = "0.7.0", default-features = false }
 
 [dependencies]
-foundationdb-sys = { version = "0.7.0", path = "../foundationdb-sys", default-features = false }
-foundationdb-macros = { version = "0.1.1", path = "../foundationdb-macros" }
+foundationdb-sys = { version = "0.7.0", default-features = false }
+foundationdb-macros = { version = "0.1.1" }
 futures = "0.3.21"
 memchr = "2.5.0"
 rand = { version = "0.8.5", features = ["default", "small_rng"] }


### PR DESCRIPTION
Bazel doesn't like the relative dependencies, but we don't really need
them since we are only changing the main package.

THIS SHOULD NOT BE MERGED