### PR TITLE
fix: Align slice memory before dereference

### DIFF
--- a/foundationdb/src/fdb_keys.rs
+++ b/foundationdb/src/fdb_keys.rs
@@ -10,6 +10,7 @@
 
 use crate::error;
 use crate::future::FdbFutureHandle;
+use crate::mem::read_unaligned_slice;
 use crate::{FdbError, FdbResult};
 use foundationdb_sys as fdb_sys;
 use std::fmt;
@@ -42,10 +43,7 @@ impl Deref for FdbKeys {
     fn deref(&self) -> &Self::Target {
         assert_eq_size!(FdbKey, fdb_sys::FDBKey);
         assert_eq_align!(FdbKey, fdb_sys::FDBKey);
-        unsafe {
-            &*(std::slice::from_raw_parts(self.keys, self.len as usize)
-                as *const [fdb_sys::FDBKey] as *const [FdbKey])
-        }
+        unsafe { &*(read_unaligned_slice(self.keys as *const FdbKey, self.len as usize)) }
     }
 }
 
@@ -160,7 +158,7 @@ pub struct FdbKey(fdb_sys::FDBKey);
 impl FdbKey {
     /// retrieves the associated key
     pub fn key(&self) -> &[u8] {
-        unsafe { std::slice::from_raw_parts(self.0.key as *const u8, self.0.key_length as usize) }
+        unsafe { &*read_unaligned_slice(self.0.key as *const u8, self.0.key_length as usize) }
     }
 }
 

--- a/foundationdb/src/lib.rs
+++ b/foundationdb/src/lib.rs
@@ -23,6 +23,7 @@ mod keyselector;
 #[cfg(any(feature = "fdb-7_1"))]
 #[deny(missing_docs)]
 pub mod mapped_key_values;
+mod mem;
 /// Generated configuration types for use with the various `set_option` functions
 #[allow(clippy::all)]
 pub mod options;

--- a/foundationdb/src/mem.rs
+++ b/foundationdb/src/mem.rs
@@ -1,0 +1,14 @@
+use std::{alloc::Layout, ptr::copy_nonoverlapping};
+
+/** Foundationdb uses arenas for allocation which are not aligned.
+https://github.com/apple/foundationdb/blob/7aa578f616c24b60436429645427485b97520286/flow/Arena.cpp#L28-L31
+
+Rust does not allow dereferencing unaligned pointers, so we copy the memory first to an aligned
+pointer before constructing our slice.
+**/
+pub(crate) unsafe fn read_unaligned_slice<T>(src: *const T, len: usize) -> *const [T] {
+    let layout = Layout::array::<T>(len).expect("failed to create slice memory layout");
+    let aligned = std::alloc::alloc(layout);
+    copy_nonoverlapping(src as *const u8, aligned, layout.size());
+    std::slice::from_raw_parts(aligned as *const T, len)
+}


### PR DESCRIPTION
Dereferencing unaligned pointers is generally UB and not allowed in rust

Version 1.70 adds checks for unaligned pointer dereference when debug
assertions are used.

https://github.com/rust-lang/rust/pull/98112

However, in this PR we eliminate the unaligned pointer dereferences by
copying the slice memory to an aligned pointer before dereferencing.

Fixes #90